### PR TITLE
[MCA-990] Publish to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,9 +1,0 @@
-src
-node_modules
-.eslintrc
-.npmignore
-.prettierignore
-.prettierrc.json
-jest.config.js
-package.json
-yarn.lock

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "banxware-link-intergration-client-ts",
+  "name": "@banxware/encoder-ts",
   "version": "1.0.0",
   "engines": {
     "node": ">=14.15.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@banxware/encoder-ts",
   "version": "1.0.0",
+  "description": "An encoder library to build the encrypted merchant information needed to integrate platforms with the Banxware loan application.",
+  "homepage": "https://github.com/Banxware/banxware-encoder-ts#readme",
+  "repository": "github:Banxware/banxware-encoder-ts",
+  "license": "ISC",
   "engines": {
     "node": ">=14.15.4"
   },
@@ -10,7 +14,6 @@
     "build": "rimraf ./lib && tsc",
     "lint": "eslint . --ext .ts"
   },
-  "license": "ISC",
   "devDependencies": {
     "@babel/core": "^7.15.5",
     "@babel/plugin-transform-runtime": "^7.15.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "homepage": "https://github.com/Banxware/banxware-encoder-ts#readme",
   "repository": "github:Banxware/banxware-encoder-ts",
   "license": "ISC",
+  "files": ["lib", "resources"],
   "engines": {
     "node": ">=14.15.4"
   },


### PR DESCRIPTION
These changes allow us to publish the lib to the npm registry. The following steps are needed:

```
npm run build
npm login
npm publish --access public
```

I have just done this for v1.0.0 so it's now available from npm.